### PR TITLE
Documentation and feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ keywords = [
 
 [dependencies]
 env_logger = { version = "0.8.2", features = ["regex"], default-features = false }
+lazy_static = { version = "1.4.0", optional = true }
 log = { version = "0.4.11", features = ["std"] }
 time = "0.2.23"
-lazy_static = { version = "1.4.0", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 bytes = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ keywords = [
 env_logger = { version = "0.8.2", features = ["regex"], default-features = false }
 log = { version = "0.4.11", features = ["std"] }
 time = "0.2.23"
+lazy_static = { version = "1.4.0", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 bytes = "1.0.0"
@@ -30,3 +31,8 @@ winapi = { version = "0.3.9", features = ["processthreadsapi"] }
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.2.1"
+
+[features]
+default = ["locked"]
+tls = []
+locked = ["lazy_static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ log = { version = "0.4.11", features = ["std"] }
 time = "0.2.23"
 
 [target.'cfg(target_os = "android")'.dependencies]
-bytes = "1.0.0"
+bytes = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.81"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,6 @@ winapi = { version = "0.3.9", features = ["processthreadsapi"] }
 redox_syscall = "0.2.1"
 
 [features]
-default = ["locked"]
+default = ["shared"]
 tls = []
-locked = ["lazy_static"]
+shared = ["lazy_static"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ the log messages are sent to Android's logd socket.
 
 ## Other OS
 For other Operating Systems the logging messages are sent to standard out.
-These are displayed in logd format.
+These are displayed in the format that 
+[logcat](https://developer.android.com/studio/command-line/logcat) expects.
 
 # Usage
 First, add this to your Cargo.toml

--- a/README.md
+++ b/README.md
@@ -2,3 +2,58 @@
 
 logd-logger
 ===========
+A library to simplify logging on Android.
+
+The library provides a logd implementation for the API of 
+[log](https://crates.io/crates/log).
+Only one logging implementation may exist at runtime for rusts log API.
+Logd-logger is configured once when initiating.
+Messages are sent using the macros `error!`, `warn!`, `info!`, `debug!` and `trace!`.
+
+# Usage
+
+First, add this to your Cargo.toml
+
+```toml
+[dependencies]
+logd-logger = "0.1.0"
+```
+
+Next:
+In the example the logging is initialized. First a [`Builder`] is created.
+Then the log level is set. All messages with lower log level are dropped.
+Then a tag is set which is added in front of each log message.
+Next, the module name is set to be prepended.
+After the configuration, it is tried to initialize the global logger.
+
+Afterwards five different macros can be used for logging.
+These are named after their log level.
+
+```rust
+use log::*;
+use logd_logger;
+
+fn main() {
+    logd_logger::builder()
+    .parse_filters("debug")
+    .tag("log_tag")
+    .prepend_module(true)
+    .init();
+
+    trace!("trace message: is not logged");
+    debug!("debug message");
+    info!("info message");
+    warn!("warn message");
+    error!("error message");
+}
+
+```
+
+# Features
+For use on Android it is possible to select whether all log messages should
+be sent over a shared socket or whether each thread should manage its own
+socket.
+Default feature is a shared socket.
+For thread locale sockets the feature flag `tls` needs to be set, and the
+default features must be disabled with `--no-default-features`.
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ For other Operating Systems the logging messages are sent to standard out.
 These are displayed in logd format.
 
 # Usage
-
 First, add this to your Cargo.toml
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Only one logging implementation may exist at runtime for rusts log API.
 Logd-logger is configured once when initiating.
 Messages are sent using the macros `error!`, `warn!`, `info!`, `debug!` and `trace!`.
 
+## Android
+In case logd-logger is compiled for Android, 
+the log messages are sent to Android's logd socket.
+
+## Other OS
+For other Operating Systems the logging messages are sent to standard out.
+These are displayed in logd format.
+
 # Usage
 
 First, add this to your Cargo.toml

--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
-![CI](https://github.com/flxo/logd-logger/workflows/CI/badge.svg)
+<!-- cargo-sync-readme start -->
 
-logd-logger
-===========
+# `logd-logger`
 A library to simplify logging on Android.
 
-The library provides a logd implementation for the API of 
-[log](https://crates.io/crates/log).
-Only one logging implementation may exist at runtime for rusts log API.
-Logd-logger is configured once when initiating.
-Messages are sent using the macros `error!`, `warn!`, `info!`, `debug!` and `trace!`.
+The library provides a logd implementation for the API of [log].
+logd-logger is configured once when initiating.
+Messages are sent using the macros [`error!`], [`warn!`], [`info!`], [`debug!`] and [`trace!`].
+
+[log]: https://docs.rs/log/*/log/
+[`error!`]: https://docs.rs/log/*/log/macro.error.html
+[`warn!`]: https://docs.rs/log/*/log/macro.warn.html
+[`info!`]: https://docs.rs/log/*/log/macro.info.html
+[`debug!`]: https://docs.rs/log/*/log/macro.debug.html
+[`trace!`]: https://docs.rs/log/*/log/macro.trace.html
 
 ## Android
-In case logd-logger is compiled for Android, 
-the log messages are sent to Android's logd socket.
+In case logd-logger is compiled for Android, the log messages are sent to Android's logd socket.
 
 ## Other OS
 For other Operating Systems the logging messages are sent to standard out.
-These are displayed in the format that 
-[logcat](https://developer.android.com/studio/command-line/logcat) expects.
+These are displayed in the format that [logcat] expects.
+
+[logcat]: https://developer.android.com/studio/command-line/logcat
 
 # Usage
 First, add this to your Cargo.toml
@@ -34,8 +38,7 @@ Then a tag is set which is added in front of each log message.
 Next, the module name is set to be prepended.
 After the configuration, it is tried to initialize the global logger.
 
-Afterwards five different macros can be used for logging.
-These are named after their log level.
+[`Builder]: crate::Builder
 
 ```rust
 use log::*;
@@ -43,10 +46,10 @@ use logd_logger;
 
 fn main() {
     logd_logger::builder()
-    .parse_filters("debug")
-    .tag("log_tag")
-    .prepend_module(true)
-    .init();
+        .parse_filters("debug")
+        .tag("log_tag")
+        .prepend_module(true)
+        .init();
 
     trace!("trace message: is not logged");
     debug!("debug message");
@@ -65,3 +68,4 @@ Default feature is a shared socket.
 For thread locale sockets the feature flag `tls` needs to be set, and the
 default features must be disabled with `--no-default-features`.
 
+<!-- cargo-sync-readme end -->

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,6 @@
 //! Next, the module name is set to be prepended.
 //! After the configuration, it is tried to initialize the global logger.
 //!
-//! Afterwards five different macros can be used for logging.
-//! These are named after their log level.
-//!
 //! ```
 //! use log::*;
 //! use logd_logger;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,6 +413,13 @@ impl Log for Logger {
     fn flush(&self) {}
 }
 
+/// Returns a default [`Builder`] for configuration and initialization of logging.
+///
+/// With the help of the [`Builder`] the logging is configured.
+/// The tag, filter and buffer can be set.
+/// Additionally it is possible to set whether the modul path appears in a log message.
+///
+/// After a call to [`init`](Builder::init) the global logger is initialized with the configuration.
 pub fn builder<'a>() -> Builder<'a> {
     Builder::default()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,10 @@ thread_local! {
     };
 }
 
+/// Builder for initializing logger
+///
+/// The builder is used to initialize the logging framework for later use.
+/// It provides
 #[derive(Default)]
 pub struct Builder<'a> {
     filter: FilterBuilder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,33 +428,33 @@ impl Log for Logger {
         let priority: Priority = record.metadata().level().into();
 
         #[cfg(target_os = "android")]
-            {
-                let timestamp = std::time::SystemTime::now();
+        {
+            let timestamp = std::time::SystemTime::now();
 
-                let tag = if let Some(ref tag) = self.tag {
-                    tag
-                } else {
-                    record.module_path().unwrap_or_default()
-                };
+            let tag = if let Some(ref tag) = self.tag {
+                tag
+            } else {
+                record.module_path().unwrap_or_default()
+            };
 
-                let tag_len = tag.bytes().len() + 1;
-                let message_len = message.bytes().len() + 1;
+            let tag_len = tag.bytes().len() + 1;
+            let message_len = message.bytes().len() + 1;
 
-                let mut buffer = bytes::BytesMut::with_capacity(12 + tag_len + message_len);
+            let mut buffer = bytes::BytesMut::with_capacity(12 + tag_len + message_len);
 
-                buffer.put_u8(self._buffer_id.into());
-                buffer.put_u16_le(thread::id() as u16);
-                let timestamp = timestamp
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .expect("Failed to aquire time");
-                buffer.put_u32_le(timestamp.as_secs() as u32);
-                buffer.put_u32_le(timestamp.subsec_nanos());
-                buffer.put_u8(priority as u8);
-                buffer.put(tag.as_bytes());
-                buffer.put_u8(0);
+            buffer.put_u8(self._buffer_id.into());
+            buffer.put_u16_le(thread::id() as u16);
+            let timestamp = timestamp
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("Failed to aquire time");
+            buffer.put_u32_le(timestamp.as_secs() as u32);
+            buffer.put_u32_le(timestamp.subsec_nanos());
+            buffer.put_u8(priority as u8);
+            buffer.put(tag.as_bytes());
+            buffer.put_u8(0);
 
-                buffer.put(message.as_bytes());
-                buffer.put_u8(0);
+            buffer.put(message.as_bytes());
+            buffer.put_u8(0);
 
                 SOCKET.with(|f| f.send(&buffer).expect("Logd socket error"));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,16 +71,23 @@ impl From<log::Level> for Priority {
     }
 }
 
-/// Log buffer ids
+/// Different Log Buffer for Android
 #[derive(Clone, Copy, Debug)]
 #[repr(u8)]
 pub enum Buffer {
+    /// Main Buffer with id 0
     Main,
+    /// Radio Buffer with id 1
     Radio,
+    /// Event Buffer with id 2
     Events,
+    /// System Buffer with id 3
     System,
+    /// Crash Buffer with id 4
     Crash,
+    /// Kernel Buffer with id 5
     Kernel,
+    /// User defined Buffer
     Custom(u8),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl From<Buffer> for u8 {
 
 #[cfg(target_os = "android")]
 thread_local! {
-    pub static SOCKET: UnixDatagram = {
+     static SOCKET: UnixDatagram = {
         let socket = std::os::unix::net::UnixDatagram::unbound().expect("Failed to create socket");
         socket.connect("/dev/socket/logdw").expect("Failed to connect to /dev/socket/logdw");
         socket

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,56 @@
+//! `logd-logger`
+//! A library to simplify logging on Android.
+//!
+//! The library provides a logd implementation for the API of [log](../log/index.html).
+//! logd-logger is configured once when initiating.
+//! Messages are sent using the macros [`error!`], [`warn!`], [`info!`], [`debug!`] and [`trace!`].
+//!
+//! [`error!`]: ../log/macro.error.html
+//! [`warn!`]: ../log/macro.warn.html
+//! [`info!`]: ../log/macro.info.html
+//! [`debug!`]: ../log/macro.debug.html
+//! [`trace!`]: ../log/macro.trace.html
+//!
+//! # Usage
+//!
+//! First, add this to your Cargo.toml
+//!
+//! ```toml
+//! [dependencies]
+//! logd-logger = "0.1.0"
+//! ```
+//!
+//! Next:
+//! In the exampel the logging is initialized. First a [`Builder`] is created.
+//! Then the log level is set. All messages with lower log level are dropped.
+//! Then a tag is set which is added in front of each log message.
+//! Next, the module name is set to be prepended.
+//! After the configuration, it is tried to initialize the global logger.
+//!
+//! Afterwards five different macros can be used for logging.
+//! These are named after their log level.
+//!
+//! ```
+//! use log::*;
+//! use logd_logger;
+//!
+//! fn main() {
+//!     logd_logger::builder()
+//!         .parse_filters("debug")
+//!         .tag("log_tag")
+//!         .prepend_module(true)
+//!         .init();
+//!
+//!     trace!("trace message: is not logged");
+//!     debug!("debug message");
+//!     info!("info message");
+//!     warn!("warn message");
+//!     error!("error message");
+//! }
+//!
+//! ```
+
+#![deny(missing_docs)]
 #[cfg(target_os = "android")]
 use bytes::BufMut;
 use env_logger::filter::{Builder as FilterBuilder, Filter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ impl From<log::Level> for Priority {
     }
 }
 
-/// Different Log Buffer for Android
+/// Log buffer ids
 #[derive(Clone, Copy, Debug)]
 #[repr(u8)]
 pub enum Buffer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,5 +514,9 @@ impl Log for Logger {
 ///
 /// After a call to [`init`](Builder::init) the global logger is initialized with the configuration.
 pub fn builder<'a>() -> Builder<'a> {
+    assert!(cfg!(any(
+        all(feature = "tls", not(feature = "locked")),
+        all(feature = "locked", not(feature = "tls"))
+    )));
     Builder::default()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,8 +456,16 @@ impl Log for Logger {
             buffer.put(message.as_bytes());
             buffer.put_u8(0);
 
+            #[cfg(all(feature = "tls", not(feature = "locked"), target_os = "android"))]
+            {
                 SOCKET.with(|f| f.send(&buffer).expect("Logd socket error"));
             }
+
+            #[cfg(all(feature = "locked", not(feature = "tls"), target_os = "android"))]
+            {
+                SOCKET.send(&buffer).expect("Logd socket error");
+            }
+        }
 
         #[cfg(not(target_os = "android"))]
             {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,24 +468,24 @@ impl Log for Logger {
         }
 
         #[cfg(not(target_os = "android"))]
-            {
-                let datetime = ::time::OffsetDateTime::now_utc();
-                let tag = if let Some(ref tag) = self.tag {
-                    tag.to_string()
-                } else {
-                    record.module_path().map(str::to_string).unwrap_or_default()
-                };
-                println!(
-                    "{}.{} {} {} {} {}: {}",
-                    datetime.format("%Y-%m-%d %T"),
-                    &datetime.format("%N")[..3],
-                    std::process::id(),
-                    thread::id(),
-                    priority,
-                    tag,
-                    message
-                );
-            }
+        {
+            let datetime = ::time::OffsetDateTime::now_utc();
+            let tag = if let Some(ref tag) = self.tag {
+                tag
+            } else {
+                record.module_path().unwrap_or_default()
+            };
+            println!(
+                "{}.{} {} {} {} {}: {}",
+                datetime.format("%Y-%m-%d %T"),
+                &datetime.format("%N")[..3],
+                std::process::id(),
+                thread::id(),
+                priority,
+                tag,
+                message
+            );
+        }
     }
 
     #[cfg(not(target_os = "android"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,8 +220,8 @@ impl<'a> Builder<'a> {
     /// # Examples
     ///
     /// ```
-    /// use logd_logger::Builder;
-    /// use logd_logger::Buffer;
+    /// # use logd_logger::Builder;
+    /// # use logd_logger::Buffer;
     ///
     /// let mut builder = Builder::new();
     ///
@@ -239,7 +239,7 @@ impl<'a> Builder<'a> {
     /// # Examples
     ///
     /// ```
-    /// use logd_logger::Builder;
+    /// # use logd_logger::Builder;
     ///
     /// let mut builder = Builder::new();
     ///
@@ -257,7 +257,7 @@ impl<'a> Builder<'a> {
     /// # Examples
     ///
     /// ```
-    /// use logd_logger::Builder;
+    /// # use logd_logger::Builder;
     ///
     /// let mut builder = Builder::new();
     ///
@@ -276,8 +276,8 @@ impl<'a> Builder<'a> {
     /// Only include messages for warning and above for logs in `path::to::module`:
     ///
     /// ```
-    /// use log::LevelFilter;
-    /// use logd_logger::Builder;
+    /// # use log::LevelFilter;
+    /// # use logd_logger::Builder;
     ///
     /// let mut builder = Builder::new();
     ///
@@ -295,8 +295,8 @@ impl<'a> Builder<'a> {
     /// Only include messages for warning and above for logs in `path::to::module`:
     ///
     /// ```
-    /// use log::LevelFilter;
-    /// use logd_logger::Builder;
+    /// # use log::LevelFilter;
+    /// # use logd_logger::Builder;
     ///
     /// let mut builder = Builder::new();
     ///
@@ -317,8 +317,8 @@ impl<'a> Builder<'a> {
     /// Only include messages for warning and above for logs in `path::to::module`:
     ///
     /// ```
-    /// use log::LevelFilter;
-    /// use logd_logger::Builder;
+    /// # use log::LevelFilter;
+    /// # use logd_logger::Builder;
     ///
     /// let mut builder = Builder::new();
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,56 +351,56 @@ impl Log for Logger {
         let priority: Priority = record.metadata().level().into();
 
         #[cfg(target_os = "android")]
-        {
-            let timestamp = std::time::SystemTime::now();
+            {
+                let timestamp = std::time::SystemTime::now();
 
-            let tag = if let Some(ref tag) = self.tag {
-                tag
-            } else {
-                record.module_path().unwrap_or_default()
-            };
+                let tag = if let Some(ref tag) = self.tag {
+                    tag
+                } else {
+                    record.module_path().unwrap_or_default()
+                };
 
-            let tag_len = tag.bytes().len() + 1;
-            let message_len = message.bytes().len() + 1;
+                let tag_len = tag.bytes().len() + 1;
+                let message_len = message.bytes().len() + 1;
 
-            let mut buffer = bytes::BytesMut::with_capacity(12 + tag_len + message_len);
+                let mut buffer = bytes::BytesMut::with_capacity(12 + tag_len + message_len);
 
-            buffer.put_u8(self._buffer_id.into());
-            buffer.put_u16_le(thread::id() as u16);
-            let timestamp = timestamp
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("Failed to aquire time");
-            buffer.put_u32_le(timestamp.as_secs() as u32);
-            buffer.put_u32_le(timestamp.subsec_nanos());
-            buffer.put_u8(priority as u8);
-            buffer.put(tag.as_bytes());
-            buffer.put_u8(0);
+                buffer.put_u8(self._buffer_id.into());
+                buffer.put_u16_le(thread::id() as u16);
+                let timestamp = timestamp
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .expect("Failed to aquire time");
+                buffer.put_u32_le(timestamp.as_secs() as u32);
+                buffer.put_u32_le(timestamp.subsec_nanos());
+                buffer.put_u8(priority as u8);
+                buffer.put(tag.as_bytes());
+                buffer.put_u8(0);
 
-            buffer.put(message.as_bytes());
-            buffer.put_u8(0);
+                buffer.put(message.as_bytes());
+                buffer.put_u8(0);
 
-            SOCKET.with(|f| f.send(&buffer).expect("Logd socket error"));
-        }
+                SOCKET.with(|f| f.send(&buffer).expect("Logd socket error"));
+            }
 
         #[cfg(not(target_os = "android"))]
-        {
-            let datetime = ::time::OffsetDateTime::now_utc();
-            let tag = if let Some(ref tag) = self.tag {
-                tag.to_string()
-            } else {
-                record.module_path().map(str::to_string).unwrap_or_default()
-            };
-            println!(
-                "{}.{} {} {} {} {}: {}",
-                datetime.format("%Y-%m-%d %T"),
-                &datetime.format("%N")[..3],
-                std::process::id(),
-                thread::id(),
-                priority,
-                tag,
-                message
-            );
-        }
+            {
+                let datetime = ::time::OffsetDateTime::now_utc();
+                let tag = if let Some(ref tag) = self.tag {
+                    tag.to_string()
+                } else {
+                    record.module_path().map(str::to_string).unwrap_or_default()
+                };
+                println!(
+                    "{}.{} {} {} {} {}: {}",
+                    datetime.format("%Y-%m-%d %T"),
+                    &datetime.format("%N")[..3],
+                    std::process::id(),
+                    thread::id(),
+                    priority,
+                    tag,
+                    message
+                );
+            }
     }
 
     #[cfg(not(target_os = "android"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@
 use env_logger::filter::{Builder as FilterBuilder, Filter};
 use log::{LevelFilter, Log, Metadata, SetLoggerError};
 use std::{fmt, io};
+#[cfg(target_os = "android")]
+use {bytes::BufMut, std::os::unix::net::UnixDatagram};
 #[cfg(all(feature = "shared", not(feature = "tls"), target_os = "android"))]
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,8 +200,8 @@ impl<'a> Builder<'a> {
     /// Create a new builder and configure filters and style:
     ///
     /// ```
-    /// use log::LevelFilter;
-    /// use logd_logger::Builder;
+    /// # use log::LevelFilter;
+    /// # use logd_logger::Builder;
     ///
     /// let mut builder = Builder::new();
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,14 @@
 //! }
 //!
 //! ```
+//!
+//! # Features
+//! For use on Android it is possible to select whether all log messages should
+//! be sent over a shared socket or whether each thread should manage its own
+//! socket.
+//! Default feature is a shared socket.
+//! For thread locale sockets the feature flag `tls` needs to be set and the
+//! default features must be disabled.
 
 #![deny(missing_docs)]
 #[cfg(target_os = "android")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! ```
 //!
 //! Next:
-//! In the exampel the logging is initialized. First a [`Builder`] is created.
+//! In the example the logging is initialized. First a [`Builder`] is created.
 //! Then the log level is set. All messages with lower log level are dropped.
 //! Then a tag is set which is added in front of each log message.
 //! Next, the module name is set to be prepended.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,7 @@ impl Log for Logger {
                 record.module_path().map(str::to_string).unwrap_or_default()
             };
 
-            let tag_len = tag.bytes().len();
+            let tag_len = tag.bytes().len() + 1;
             let message_len = message.bytes().len() + 1;
 
             let mut buffer = bytes::BytesMut::with_capacity(12 + tag_len + message_len);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,9 +355,9 @@ impl Log for Logger {
             let timestamp = std::time::SystemTime::now();
 
             let tag = if let Some(ref tag) = self.tag {
-                tag.clone()
+                tag
             } else {
-                record.module_path().map(str::to_string).unwrap_or_default()
+                record.module_path().unwrap_or_default()
             };
 
             let tag_len = tag.bytes().len() + 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,27 @@
-//! `logd-logger`
+//! # `logd-logger`
 //! A library to simplify logging on Android.
 //!
-//! The library provides a logd implementation for the API of [log](../log/index.html).
+//! The library provides a logd implementation for the API of [log].
 //! logd-logger is configured once when initiating.
 //! Messages are sent using the macros [`error!`], [`warn!`], [`info!`], [`debug!`] and [`trace!`].
 //!
-//! [`error!`]: ../log/macro.error.html
-//! [`warn!`]: ../log/macro.warn.html
-//! [`info!`]: ../log/macro.info.html
-//! [`debug!`]: ../log/macro.debug.html
-//! [`trace!`]: ../log/macro.trace.html
+//! [log]: https://docs.rs/log/*/log/
+//! [`error!`]: https://docs.rs/log/*/log/macro.error.html
+//! [`warn!`]: https://docs.rs/log/*/log/macro.warn.html
+//! [`info!`]: https://docs.rs/log/*/log/macro.info.html
+//! [`debug!`]: https://docs.rs/log/*/log/macro.debug.html
+//! [`trace!`]: https://docs.rs/log/*/log/macro.trace.html
+//!
+//! ## Android
+//! In case logd-logger is compiled for Android, the log messages are sent to Android's logd socket.
+//!
+//! ## Other OS
+//! For other Operating Systems the logging messages are sent to standard out.
+//! These are displayed in the format that [logcat] expects.
+//!
+//! [logcat]: https://developer.android.com/studio/command-line/logcat
 //!
 //! # Usage
-//!
 //! First, add this to your Cargo.toml
 //!
 //! ```toml
@@ -26,6 +35,8 @@
 //! Then a tag is set which is added in front of each log message.
 //! Next, the module name is set to be prepended.
 //! After the configuration, it is tried to initialize the global logger.
+//!
+//! [`Builder]: crate::Builder
 //!
 //! ```
 //! use log::*;
@@ -52,8 +63,8 @@
 //! be sent over a shared socket or whether each thread should manage its own
 //! socket.
 //! Default feature is a shared socket.
-//! For thread locale sockets the feature flag `tls` needs to be set and the
-//! default features must be disabled.
+//! For thread locale sockets the feature flag `tls` needs to be set, and the
+//! default features must be disabled with `--no-default-features`.
 
 #![deny(missing_docs)]
 use env_logger::filter::{Builder as FilterBuilder, Filter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,11 +68,14 @@ use {bytes::BufMut, std::os::unix::net::UnixDatagram};
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(target_os = "android")]
+const LOGDW: &str = "/dev/socket/logdw";
+
 #[cfg(all(feature = "tls", not(feature = "shared"), target_os = "android"))]
 thread_local! {
      static SOCKET: UnixDatagram = {
         let socket = UnixDatagram::unbound().expect("Failed to create socket");
-        socket.connect("/dev/socket/logdw").expect("Failed to connect to /dev/socket/logdw");
+        socket.connect(LOGDW).expect("Failed to connect to /dev/socket/logdw");
         socket
     };
 }
@@ -80,9 +83,7 @@ thread_local! {
 lazy_static! {
     static ref SOCKET: UnixDatagram = {
         let socket = UnixDatagram::unbound().expect("Failed to create socket");
-        socket
-            .connect("/dev/socket/logdw")
-            .expect("Failed to connect to /dev/socket/logdw");
+        socket.connect(LOGDW).expect("Failed to connect to /dev/socket/logdw");
         socket
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,15 +71,15 @@ extern crate lazy_static;
 #[cfg(all(feature = "tls", not(feature = "shared"), target_os = "android"))]
 thread_local! {
      static SOCKET: UnixDatagram = {
-        let socket = std::os::unix::net::UnixDatagram::unbound().expect("Failed to create socket");
+        let socket = UnixDatagram::unbound().expect("Failed to create socket");
         socket.connect("/dev/socket/logdw").expect("Failed to connect to /dev/socket/logdw");
         socket
     };
 }
 #[cfg(all(feature = "shared", not(feature = "tls"), target_os = "android"))]
 lazy_static! {
-    static ref SOCKET: std::os::unix::net::UnixDatagram = {
-        let socket = std::os::unix::net::UnixDatagram::unbound().expect("Failed to create socket");
+    static ref SOCKET: UnixDatagram = {
+        let socket = UnixDatagram::unbound().expect("Failed to create socket");
         socket
             .connect("/dev/socket/logdw")
             .expect("Failed to connect to /dev/socket/logdw");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,14 +464,10 @@ impl Log for Logger {
             buffer.put_u8(0);
 
             #[cfg(all(feature = "tls", not(feature = "shared"), target_os = "android"))]
-            {
-                SOCKET.with(|f| f.send(&buffer).expect("Logd socket error"));
-            }
+            SOCKET.with(|f| f.send(&buffer).expect("Logd socket error"));
 
             #[cfg(all(feature = "shared", not(feature = "tls"), target_os = "android"))]
-            {
-                SOCKET.send(&buffer).expect("Logd socket error");
-            }
+            SOCKET.send(&buffer).expect("Logd socket error");
         }
 
         #[cfg(not(target_os = "android"))]


### PR DESCRIPTION
Added the ability to switch between thread local and a split socket via a feature flag.

An assert was added in the builder if only one of the two flags is set. 
Is there a way to check this at compile time?

Documentation was added. 

Currently there is still a compiler warning that UnixDatagram is not used when compiling for a shared socket. 