### PR TITLE
feat: EventValues from heterogenous tuples

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -132,6 +132,58 @@ where
     }
 }
 
+impl<T, U> From<(T, U)> for EventValue
+where
+    T: Into<EventValue>,
+    U: Into<EventValue>,
+{
+    fn from(value: (T, U)) -> Self {
+        EventValue::List(vec![value.0.into(), value.1.into()])
+    }
+}
+
+impl<T, U, V> From<(T, U, V)> for EventValue
+where
+    T: Into<EventValue>,
+    U: Into<EventValue>,
+    V: Into<EventValue>,
+{
+    fn from(value: (T, U, V)) -> Self {
+        EventValue::List(vec![value.0.into(), value.1.into(), value.2.into()])
+    }
+}
+
+impl<T, U, V, X> From<(T, U, V, X)> for EventValue
+where
+    T: Into<EventValue>,
+    U: Into<EventValue>,
+    V: Into<EventValue>,
+    X: Into<EventValue>,
+{
+    fn from(value: (T, U, V, X)) -> Self {
+        EventValue::List(vec![value.0.into(), value.1.into(), value.2.into(), value.3.into()])
+    }
+}
+
+impl<T, U, V, X, Y> From<(T, U, V, X, Y)> for EventValue
+where
+    T: Into<EventValue>,
+    U: Into<EventValue>,
+    V: Into<EventValue>,
+    X: Into<EventValue>,
+    Y: Into<EventValue>,
+{
+    fn from(value: (T, U, V, X, Y)) -> Self {
+        EventValue::List(vec![
+            value.0.into(),
+            value.1.into(),
+            value.2.into(),
+            value.3.into(),
+            value.4.into(),
+        ])
+    }
+}
+
 /// Write an event with the timestamp now to `Buffer::Events`
 /// ```
 /// use android_logd_logger::{write_event, write_event_now, Error, Event, EventValue};


### PR DESCRIPTION
So far, we were only able to serialize `Vec<T>` or iterators of `T` for one homogenous type `T`. Users were forced to pre-create an `EventValue::List` with inner `EventValue`s.

This commit adds `From` implementations for tuples ranging from 2 to 5 elements where each type can be a different one as long as all of them implement `Into<EventValue>`.

Example event description

```
# application: string
# duration: int, milli seconds
00000007 app_ready (application|3),(duration|1|3)
```

```rust
# before
let value = EventValue::List(vec![
    EventValue::String("app1".to_owned()),
    EventValue::Int(Duration::from_secs(7).as_millis() as i32),
]);
write_event_now("module_tag", ).unwrap();

# now
write_event_now("module_tag", ("app1", Duration::from_secs(7).as_millis() as i32)).unwrap();
```