### PR TITLE
fix: Log to stderr on non-android

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -620,6 +620,6 @@ fn log_record(record: &Record) -> Result<(), Error> {
         })
         .and_then(|ts| ts.format(&DATE_TIME_FORMAT).map_err(|e| Error::Timestamp(e.to_string())))?;
 
-    println!("{} {} {} {} {}: {}", timestamp, pid, thread_id, priority, tag, message);
+    eprintln!("{} {} {} {} {}: {}", timestamp, pid, thread_id, priority, tag, message);
     Ok(())
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -261,7 +261,7 @@ impl Log for LoggerImpl {
     #[cfg(not(target_os = "android"))]
     fn flush(&self) {
         use std::io::Write;
-        io::stdout().flush().ok();
+        io::stderr().flush().ok();
     }
 
     #[cfg(target_os = "android")]


### PR DESCRIPTION
Since program output is generally printed to `stdout`, logs and other debug information are generally expected on `stderr`. 