### PR TITLE
Remove unnecessary arguments for log(...)

### DIFF
--- a/src/logd.rs
+++ b/src/logd.rs
@@ -134,8 +134,6 @@ fn smoke() {
         let timestamp = SystemTime::now();
         let record = Record {
             timestamp,
-            pid: std::process::id() as u16,
-            thread_id: thread::id() as u16,
             buffer_id: Buffer::Main,
             tag: "test",
             priority: Priority::Info,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,8 +1,8 @@
-use crate::{thread, Buffer, Priority, Record, TagMode};
+use crate::{Buffer, Priority, Record, TagMode};
 use env_logger::filter::{Builder, Filter};
 use log::{LevelFilter, Log, Metadata};
 use parking_lot::RwLock;
-use std::{io, process, sync::Arc, time::SystemTime};
+use std::{io, sync::Arc, time::SystemTime};
 
 /// Logger configuration.
 pub(crate) struct Configuration {
@@ -240,8 +240,6 @@ impl Log for LoggerImpl {
         let timestamp = SystemTime::now();
         let record = Record {
             timestamp,
-            pid: process::id() as u16,
-            thread_id: thread::id() as u16,
             buffer_id: configuration.buffer_id,
             tag,
             priority,

--- a/src/pmsg.rs
+++ b/src/pmsg.rs
@@ -1,8 +1,9 @@
-use crate::{logging_iterator::NewlineScaledChunkIterator, Buffer, Priority, Record};
+use crate::{logging_iterator::NewlineScaledChunkIterator, thread, Buffer, Priority, Record};
 use bytes::{BufMut, BytesMut};
 use std::{
     fs::{File, OpenOptions},
     io::{self, Write},
+    process,
     time::UNIX_EPOCH,
 };
 
@@ -63,11 +64,11 @@ fn log_pmsg_packet(record: &Record, msg_part: &str) {
     let mut buffer = bytes::BytesMut::with_capacity(packet_len as usize);
     let timestamp = record.timestamp.duration_since(UNIX_EPOCH).unwrap();
 
-    write_pmsg_header(&mut buffer, packet_len, DUMMY_UID, record.pid);
+    write_pmsg_header(&mut buffer, packet_len, DUMMY_UID, process::id() as u16);
     write_log_header(
         &mut buffer,
         record.buffer_id,
-        record.thread_id,
+        thread::id() as u16,
         timestamp.as_secs() as u32,
         timestamp.subsec_nanos(),
     );


### PR DESCRIPTION
We don't need to specify PID in the public log(...) function because logd obtains it from the credentials ([0]), which we don't fill explicitly (no stable api in Rust for that now). However, in our case (logdw socket has enabled passcred option) the kernel does it automatically ([1]).
We also shouldn't pass TID (in public log(...)) because we always use our thread id for that purpose.

 [0] https://chromium.googlesource.com/aosp/platform/system/logging/+/refs/heads/factory-ambassador-14265.B/logd/LogListener.cpp#119
 [1] https://elixir.bootlin.com/linux/v6.5/source/net/unix/af_unix.c#L1857