### PR TITLE
fix: Enable lowering log level below startup value

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -169,7 +169,9 @@ impl Logger {
     ///
     /// See the module documentation for more details.
     pub fn parse_filters(&mut self, filters: &str) -> &mut Self {
-        self.configuration.write().filter = Builder::default().parse(filters).build();
+        let filter = Builder::default().parse(filters).build();
+        log::set_max_level(filter.filter());
+        self.configuration.write().filter = filter;
         self
     }
 


### PR DESCRIPTION
`Logger::parse_filters` allows to change the log filter even after the logger has been initialized. However, it was not possible to see logs which were above the level set at startup. E.g. if the logger was initialized with `debug`, setting it to `trace` at runtime did not work since the filter of the global logging facade filtered out the `trace` logs.

This commit fixes the issue by calling `log::set_max_level` with the level from the updated log filter.